### PR TITLE
Work around for IE8

### DIFF
--- a/dug.js
+++ b/dug.js
@@ -8,6 +8,33 @@
 
 */
 
+/* 
+ Work around for non ECMA-262 browsers (IE8)
+ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach 
+*/
+if (!Array.prototype.forEach)
+{
+  Array.prototype.forEach = function(fun /*, thisArg */)
+  {
+    "use strict";
+
+    if (this === void 0 || this === null)
+      throw new TypeError();
+
+    var t = Object(this);
+    var len = t.length >>> 0;
+    if (typeof fun !== "function")
+      throw new TypeError();
+
+    var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+    for (var i = 0; i < len; i++)
+    {
+      if (i in t)
+        fun.call(thisArg, t[i], i, t);
+    }
+  };
+}
+
 var dug = function( opts ){
 
 	if(this.constructor != dug ){


### PR DESCRIPTION
forEach was added to the ECMA-262 standard in the 5th edition; as such it may not be present in other implementations of the standard.
