### PR TITLE
Adds package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dug.js",
+  "version": "1.0.0",
+  "description": "A JSONP to HTML script",
+  "main": "dug.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rogie/Dug.js"
+  },
+  "author": "Rogie King",
+  "license": "WTFPL",
+  "bugs": {
+    "url": "https://github.com/rogie/Dug.js/issues"
+  }
+}


### PR DESCRIPTION
This would probably be better if it included the necessary changes for Browserify support, but I was unable to figure that part out. It’s still nice to have, I think.

I left it open whether it should be `private: true` or not.